### PR TITLE
Fix errors in segmentation parsing and reference frame update timing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn process_obu<R: io::Read>(
                 if fh.show_frame || fh.show_existing_frame {
                     seq.rfman.output_process(&fh);
                 }
-                if obu.obu_type == obu::OBU_FRAME {
+                if !fh.show_existing_frame {
                     if config.verbose > 2 {
                         println!("  {:?}", seq.rfman);
                     }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -872,7 +872,7 @@ fn parse_segmentation_params<R: io::Read>(
             sp.segmentation_update_data = br.f::<bool>(1)?; // f(1)
         }
         if sp.segmentation_update_data {
-            for i in 0..MAX_SEGMENTS {
+            for _ in 0..MAX_SEGMENTS {
                 for j in 0..SEG_LVL_MAX {
                     let feature_value;
                     let feature_enabled = br.f::<bool>(1)?; // f(1)
@@ -880,7 +880,7 @@ fn parse_segmentation_params<R: io::Read>(
                     // FeatureEnabled[i][j] = feature_enabled
                     let mut clipped_value = 0;
                     if feature_enabled {
-                        let bits_to_read = Segmentation_Feature_Bits[i];
+                        let bits_to_read = Segmentation_Feature_Bits[j];
                         let limit = Segmentation_Feature_Max[j];
                         if Segmentation_Feature_Signed[j] == 1 {
                             feature_value = br.su(1 + bits_to_read)?; // su(1+bitsToRead)


### PR DESCRIPTION
Fixes #1, thanks to @jamrial for finding the cause.

Test result looks OK:
```
rzumer@gekai:~/dev/vimeo/av1parser$ cargo run -- streams/*
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/av1parser streams/aom_cx_set_ref_av1.ivf streams/av1.annexb.obu streams/av1.ivf streams/av1_lag5_frames10.webm streams/av1_obu_test.ivf streams/av1_test.webm streams/av1.webm streams/cdf_mode_0.webm streams/cdf_mode_1.webm streams/cdf_mode_2.webm streams/download.py streams/fetchmpd.py streams/note.txt streams/parkjoy_error-resilient.ivf streams/parkjoy.ivf streams/parkjoy.obu streams/parkjoy.webm streams/requirements.txt streams/set_maps_av1.ivf streams/simple_encoder_av1.ivf streams/test_encode.ivf streams/twopass_encoder_av1.ivf streams/vase_tile_list.ivf`
streams/aom_cx_set_ref_av1.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(LAST2), show@4
  #5 InterFrame, update(LAST), show@5
  #6 InterFrame, update(INTRA), show@6
  #7 InterFrame, update(LAST2), show@7
  #8 InterFrame, update(LAST), show@8
  #9 InterFrame, update(INTRA), show@9
streams/av1.annexb.obu: Raw stream
streams/av1.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/av1_lag5_frames10.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(ALTREF), (refonly)
  #2 InterFrame, update(LAST2), show@1
  #3 InterFrame, update(LAST), show@2
  #4 InterFrame, update(ALTREF), show@3
  #5 InterFrame, update(LAST3), (refonly)
  #6 InterFrame, update(INTRA), show@4
  #7 InterFrame, update(LAST2), show@5
  #8 InterFrame, update(LAST3), show@6
  #9 InterFrame, update(ALTREF), (refonly)
  #10 InterFrame, update(LAST), show@7
  #11 InterFrame, update(INTRA), show@8
  #12 InterFrame, update(ALTREF), show@9
streams/av1_obu_test.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/av1_test.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(LAST2), show@4
streams/av1.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/cdf_mode_0.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/cdf_mode_1.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/cdf_mode_2.webm: Matroska/WebM codec="V_AV1" size=352x288
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/download.py: Raw stream
streams/fetchmpd.py: Raw stream
streams/note.txt: Raw stream
streams/parkjoy_error-resilient.ivf: IVF codec="AV01" size=160x90 fr=50 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame*, update(ALTREF), (refonly)
  #2 InterFrame*, update(BWDREF), showable
  #3 InterFrame*, update(GOLDEN), showable
  #4 InterFrame*, update(LAST2), show@1
  #5 InterFrame*, update(INTRA), show@2
  #6 InterFrame*, update(LAST2), show@3
  #7 InterFrame*, update(LAST), showable
  #8 InterFrame*, update(GOLDEN), show@4
  #9 InterFrame*, update(LAST2), show@5
  #10 InterFrame*, update(GOLDEN), show@6
  #11 InterFrame*, update(ALTREF), show@7
  #12 InterFrame*, update(LAST), show@8
  #13 InterFrame*, update(LAST2), show@9
streams/parkjoy.ivf: IVF codec="AV01" size=160x90 fr=50 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(ALTREF), (refonly)
  #2 InterFrame, update(BWDREF), showable
  #3 InterFrame, update(GOLDEN), showable
  #4 InterFrame, update(LAST2), show@1
    #3 (GOLDEN) show@2
  #5 InterFrame, update(INTRA), show@3
    #2 (BWDREF) show@4
  #6 InterFrame, update(LAST), showable
  #7 InterFrame, update(GOLDEN), show@5
    #6 (LAST) show@6
  #8 InterFrame, update(BWDREF), show@7
  #9 InterFrame, update(GOLDEN), show@8
  #10 InterFrame, update(ALTREF), show@9
streams/parkjoy.obu: Raw stream
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(ALTREF), (refonly)
  #2 InterFrame, update(BWDREF), showable
  #3 InterFrame, update(GOLDEN), showable
  #4 InterFrame, update(LAST2), show@1
    #3 (GOLDEN) show@2
  #5 InterFrame, update(INTRA), show@3
    #2 (BWDREF) show@4
  #6 InterFrame, update(LAST), showable
  #7 InterFrame, update(GOLDEN), show@5
    #6 (LAST) show@6
  #8 InterFrame, update(BWDREF), show@7
  #9 InterFrame, update(GOLDEN), show@8
  #10 InterFrame, update(ALTREF), show@9
streams/parkjoy.webm: Matroska/WebM codec="V_AV1" size=160x90
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(ALTREF), (refonly)
  #2 InterFrame, update(BWDREF), showable
  #3 InterFrame, update(GOLDEN), showable
  #4 InterFrame, update(LAST2), show@1
    #3 (GOLDEN) show@2
  #5 InterFrame, update(INTRA), show@3
    #2 (BWDREF) show@4
  #6 InterFrame, update(LAST), showable
  #7 InterFrame, update(GOLDEN), show@5
    #6 (LAST) show@6
  #8 InterFrame, update(BWDREF), show@7
  #9 InterFrame, update(GOLDEN), show@8
  #10 InterFrame, update(ALTREF), show@9
streams/requirements.txt: Raw stream
streams/set_maps_av1.ivf: IVF codec="AV01" size=352x288 fr=2 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
  #5 InterFrame, update(LAST), show@5
  #6 InterFrame, update(INTRA), show@6
  #7 InterFrame, update(LAST2), show@7
  #8 InterFrame, update(0b00001010), show@8
  #9 InterFrame, update(INTRA), show@9
  #10 InterFrame, update(LAST2), show@10
  #11 InterFrame, update(LAST), show@11
  #12 InterFrame, update(0b00001001), show@12
  #13 InterFrame, update(LAST2), show@13
  #14 InterFrame, update(LAST), show@14
streams/simple_encoder_av1.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(LAST2), show@4
streams/test_encode.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(LAST2), show@1
  #2 InterFrame, update(LAST), show@2
  #3 InterFrame, update(INTRA), show@3
  #4 InterFrame, update(0b00001100), show@4
streams/twopass_encoder_av1.ivf: IVF codec="AV01" size=352x288 fr=30 scale=0 n=1
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(ALTREF), (refonly)
  #2 InterFrame, update(GOLDEN), showable
  #3 InterFrame, update(LAST2), show@1
    #2 (GOLDEN) show@2
  #4 InterFrame, update(LAST), showable
  #5 InterFrame, update(INTRA), show@3
    #4 (LAST) show@4
  #6 InterFrame, update(GOLDEN), show@5
  #7 InterFrame, update(ALTREF), show@6
streams/vase_tile_list.ivf: IVF codec="AV01" size=1024x1024 fr=1 scale=0 n=30
  #0 KeyFrame*, update(all), show@0
  #1 InterFrame, update(none), show@1
  #2 InterFrame, update(none), show@2
  #3 InterFrame, update(none), show@3
  #4 InterFrame, update(none), show@4
```