### PR TITLE
Add parsing for tile list OBUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Supported OBU types:
 - OBU_TEMPORAL_DELIMITER (no payload)
 - OBU_FRAME_HEADER
 - OBU_FRAME (header part only)
+- OBU_TILE_LIST (no payload)
 
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,15 @@ fn process_obu<R: io::Read>(
                 }
             }
         }
+        obu::OBU_TILE_LIST => {
+            if let Some(tl) = obu::parse_tile_list(reader) {
+                if config.verbose > 2 {
+                    println!("  {:?}", tl);
+                }
+            } else {
+                println!("  invalid TileList")
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
Displayed only with `-vvv`.