### PR TITLE
Update IVF header terminology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "av1parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av1parser"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["yoh <kawasaki.liamg@gmail.com>"]
 description = "AV1 Bitstream Parser"
 

--- a/src/ivf.rs
+++ b/src/ivf.rs
@@ -17,9 +17,9 @@ pub struct IvfHeader {
     pub codec: [u8; 4], // FourCC
     pub width: u16,     // [pel]
     pub height: u16,    // [pel]
-    pub framerate: u32,
-    pub timescale: u32,
-    pub nframes: u32,
+    pub timescale_num: u32,
+    pub timescale_den: u32,
+    pub length: u32, // nframes in libvpx, duration in ffmpeg
 }
 
 ///
@@ -69,25 +69,25 @@ pub fn parse_ivf_header(mut ivf: &[u8]) -> Result<IvfHeader, String> {
     ivf.read_exact(&mut height).unwrap();
     let width = LittleEndian::read_u16(&width);
     let height = LittleEndian::read_u16(&height);
-    // framerate (4b), timescale (4b)
-    let mut framerate = [0; 4];
-    let mut timescale = [0; 4];
-    ivf.read_exact(&mut framerate).unwrap();
-    ivf.read_exact(&mut timescale).unwrap();
-    let framerate = LittleEndian::read_u32(&framerate);
-    let timescale = LittleEndian::read_u32(&timescale);
-    // number of frames (4b)
-    let mut nframes = [0; 4];
-    ivf.read_exact(&mut nframes).unwrap();
-    let nframes = LittleEndian::read_u32(&nframes);
+    // timescale_num (4b), timescale_den (4b)
+    let mut timescale_num = [0; 4];
+    let mut timescale_den = [0; 4];
+    ivf.read_exact(&mut timescale_num).unwrap();
+    ivf.read_exact(&mut timescale_den).unwrap();
+    let timescale_num = LittleEndian::read_u32(&timescale_num);
+    let timescale_den = LittleEndian::read_u32(&timescale_den);
+    // length (4b)
+    let mut length = [0; 4];
+    ivf.read_exact(&mut length).unwrap();
+    let length = LittleEndian::read_u32(&length);
 
     Ok(IvfHeader {
-        codec: codec,
-        width: width,
-        height: height,
-        framerate: framerate,
-        timescale: timescale,
-        nframes: nframes,
+        codec,
+        width,
+        height,
+        timescale_num,
+        timescale_den,
+        length,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,14 @@ fn parse_ivf_format<R: io::Read + io::Seek>(
         Ok(hdr) => {
             let codec = String::from_utf8(hdr.codec.to_vec()).unwrap();
             println!(
-                "{}: IVF codec={:?} size={}x{} fr={} scale={} n={}",
-                fname, codec, hdr.width, hdr.height, hdr.framerate, hdr.timescale, hdr.nframes
+                "{}: IVF codec={:?} size={}x{} timescale={}/{} length={}",
+                fname,
+                codec,
+                hdr.width,
+                hdr.height,
+                hdr.timescale_num,
+                hdr.timescale_den,
+                hdr.length
             );
             if hdr.codec != FCC_AV01 {
                 println!(


### PR DESCRIPTION
Based on terms used in libvpx and FFmpeg.

Increase version to 0.2.0, because it is an API-breaking change.

For timescale, see for example https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/ivfenc.c.

For length, see https://github.com/webmproject/libvpx/blob/v1.8.1/ivfenc.c#L16 (comment) and FFmpeg's `ivfenc.c` again (codes "duration" instead of number of frames).

There is disagreement over whether or not this field should be a number of frames or a timescale-based duration. Therefore I simply renamed it "length".

If the version change is OK, can you please consider tagging (21180d82e488c42d4e7c23d12e03dc222d984a54) 0.1.0 or v0.1.0 and the commit after merging 0.2.0 or v0.2.0, to help avoid pulling breaking API changes when using av1parser as a library with Cargo?