### PR TITLE
Parse HDR10+ metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,7 @@ version = "0.2.1"
 dependencies = [
  "byteorder",
  "clap",
+ "hdr10plus",
  "hex",
 ]
 
@@ -36,6 +43,27 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8044d3388c7201657372b870f2f443256bb7c26c95a482fca79da833e0c5b"
+dependencies = [
+ "bitvec",
+]
 
 [[package]]
 name = "byteorder"
@@ -56,6 +84,22 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "hdr10plus"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71927bcf2a5dabede0e044962ac773e606f7cef4098edc10636e4c1ad3817a48"
+dependencies = [
+ "anyhow",
+ "bitvec_helpers",
 ]
 
 [[package]]
@@ -80,10 +124,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -127,3 +183,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ description = "AV1 Bitstream Parser"
 byteorder = "1.2"
 clap = "2.32"
 hex = "0.4"
+hdr10plus = { version = "1.0", optional = true }
+
+[features]
+metadata_hdr10plus = ["hdr10plus"]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2202,16 +2202,22 @@ fn parse_scalability_structure<R: io::Read>(br: &mut BitReader<R>) -> Option<Sca
 ///
 /// parse metadata_itut_t35()
 ///
+/// include all bytes in payload vec
 fn parse_itu_t_t35_metadata<R: io::Read>(br: &mut BitReader<R>) -> Option<MetadataObu> {
     let mut meta = ItutT35Metadata::default();
 
     meta.itu_t_t35_country_code = br.f::<u8>(8)?; // f(8)
+    meta.itu_t_t35_payload_bytes.push(meta.itu_t_t35_country_code);
 
     meta.itu_t_t35_country_code_extension_byte = if meta.itu_t_t35_country_code == 0xFF {
         br.f::<u8>(8) // f(8)
     } else {
         None
     };
+
+    if let Some(ext_byte) = meta.itu_t_t35_country_code_extension_byte {
+        meta.itu_t_t35_payload_bytes.push(ext_byte);
+    }
 
     while let Some(byte) = br.f::<u8>(8) {
         meta.itu_t_t35_payload_bytes.push(byte);


### PR DESCRIPTION
Now that there was a sample available, I could test the ITU T35 metadata OBUs.
Turns out the payload should contain all of the bytes.

The sample comes from here: https://github.com/AOMediaCodec/av1-hdr10plus/pull/8

I'm not too sure if a feature is really necessary, and I didn't want to rewrite the parsing so made a crate for it.

Example output when running with `cargo run --release --features=metadata_hdr10plus -- -vv out.ivf`

>  METADATA size=2+66

>    ItutT35(ItutT35Metadata { itu_t_t35_country_code: 181, itu_t_t35_country_code_extension_byte: None, itu_t_t35_payload_bytes: [181, 0, 60, 0, 1, 4, 1, 64, 0, 12, 128, 56, 34, 28, 172, 14, 18, 0, 12, 100, 8, 0, 0, 40, 97, 144, 80, 1, 140, 200, 0, 1, 144, 0, 30, 88, 0, 70, 208, 0, 166, 248, 0, 255, 24, 95, 224, 0, 66, 112, 60, 36, 140, 70, 90, 72, 158, 160, 190, 179, 61, 207, 163, 0, 128] })

>    ST2094-40 metadata
        Hdr10PlusMetadata { profile: "B", itu_t_t35_country_code: 181, itu_t_t35_terminal_provider_code: 60, itu_t_t35_terminal_provider_oriented_code: 1, application_identifier: 4, application_version: 1, num_windows: 1, processing_windows: None, targeted_system_display_maximum_luminance: 400, targeted_system_display_actual_peak_luminance_flag: false, actual_targeted_system_display: None, maxscl: [7185, 7340, 7204], average_maxrgb: 49, num_distribution_maxrgb_percentiles: 9, distribution_maxrgb: [DistributionMaxRgb { percentage: 1, percentile: 0 }, DistributionMaxRgb { percentage: 5, percentile: 6244 }, DistributionMaxRgb { percentage: 10, percentile: 99 }, DistributionMaxRgb { percentage: 25, percentile: 0 }, DistributionMaxRgb { percentage: 50, percentile: 7 }, DistributionMaxRgb { percentage: 75, percentile: 17 }, DistributionMaxRgb { percentage: 90, percentile: 41 }, DistributionMaxRgb { percentage: 95, percentile: 63 }, DistributionMaxRgb { percentage: 99, percentile: 6136 }], fraction_bright_pixels: 0, mastering_display_actual_peak_luminance_flag: false, actual_mastering_display: None, tone_mapping_flag: true, bezier_curve: Some(BezierCurve { knee_point_x: 156, knee_point_y: 240, num_bezier_curve_anchors: 9, bezier_curve_anchors: [140, 281, 420, 551, 672, 762, 819, 883, 931] }), color_saturation_mapping_flag: false, color_saturation_weight: 0 }